### PR TITLE
fix: correct package naming, smithery config, and MCP error handling

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -11,10 +11,10 @@ startCommand:
         type: boolean
         default: false
         description: Enable debug logging
-      ipapiApiToken:
+      reviewwebsiteApiKey:
         type: string
         default: ""
-        description: API token for the IP API service
+        description: API key for ReviewWeb.site API
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -24,11 +24,11 @@ startCommand:
       if (config.debug) {
         env.DEBUG = 'true';
       }
-      if (config.ipapiApiToken) {
-        env.IPAPI_API_TOKEN = config.ipapiApiToken;
+      if (config.reviewwebsiteApiKey) {
+        env.REVIEWWEBSITE_API_KEY = config.reviewwebsiteApiKey;
       }
       return { command: 'node', args: ['dist/index.js'], env };
     }
   exampleConfig:
     debug: true
-    ipapiApiToken: YOUR_API_TOKEN
+    reviewwebsiteApiKey: YOUR_API_KEY

--- a/src/utils/config.util.ts
+++ b/src/utils/config.util.ts
@@ -91,7 +91,7 @@ class ConfigLoader {
 			const config = JSON.parse(configContent);
 
 			// Determine the potential keys for the current package
-			const shortKey = 'screenshotone'; // Project-specific short key
+			const shortKey = 'reviewwebsite'; // Project-specific short key
 			const fullPackageName = this.packageName; // e.g., '@aashari/boilerplate-mcp-server'
 			const unscopedPackageName =
 				fullPackageName.split('/')[1] || fullPackageName; // e.g., 'boilerplate-mcp-server'
@@ -196,4 +196,4 @@ class ConfigLoader {
 }
 
 // Create and export a singleton instance with the package name from package.json
-export const config = new ConfigLoader('screenshotone-mcp-server');
+export const config = new ConfigLoader('reviewwebsite-mcp-server');

--- a/src/utils/constants.util.ts
+++ b/src/utils/constants.util.ts
@@ -15,10 +15,10 @@ export const VERSION = '1.0.0';
  * Package name with scope
  * Used for initialization and identification
  */
-export const PACKAGE_NAME = 'screenshotone-mcp-server';
+export const PACKAGE_NAME = 'reviewwebsite-mcp-server';
 
 /**
  * CLI command name
  * Used for binary name and CLI help text
  */
-export const CLI_NAME = 'screenshotone-mcp-server';
+export const CLI_NAME = 'reviewwebsite-mcp-server';

--- a/src/utils/error.util.ts
+++ b/src/utils/error.util.ts
@@ -101,6 +101,7 @@ export function ensureMcpError(error: unknown): McpError {
  */
 export function formatErrorForMcpTool(error: unknown): {
 	content: Array<{ type: 'text'; text: string }>;
+	isError: boolean;
 } {
 	const methodLogger = Logger.forContext(
 		'utils/error.util.ts',
@@ -116,6 +117,7 @@ export function formatErrorForMcpTool(error: unknown): {
 				text: `Error: ${mcpError.message}`,
 			},
 		],
+		isError: true,
 	};
 }
 


### PR DESCRIPTION
## Summary
- Replace leftover `screenshotone` references with `reviewwebsite` in `constants.util.ts` and `config.util.ts`
- Update `smithery.yaml` to expose `REVIEWWEBSITE_API_KEY` instead of `ipapiApiToken` from the boilerplate
- Add `isError: true` to `formatErrorForMcpTool` so MCP clients properly surface tool errors instead of showing generic "Error occurred during tool execution" messages

## Root cause analysis
The `convert_to_markdown` tool was failing with a generic error because:
1. The `.env` had an expired API key causing 401 responses
2. Error responses lacked `isError: true`, causing MCP clients to mishandle them
3. Smithery config didn't expose `REVIEWWEBSITE_API_KEY`, so hosted deployments couldn't receive the key

## Test plan
- [x] Verified API works with valid key (HTTP 201)
- [x] Verified MCP server at `https://mcp.reviewweb.site/mcp` returns correct markdown for tweet URLs
- [x] TypeScript compilation passes
- [x] Build succeeds